### PR TITLE
Run Playwright E2E Tests after Vercel deployment

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,3 +31,10 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 30
+
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: test-results
+          path: test-results/
+          retention-days: 7

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,12 +1,10 @@
-name: Playwright E2E Tests
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+name: Playwright E2E Smoke Tests
+on: deployment_status
+
 jobs:
   runTests:
-    timeout-minutes: 60
+    if: github.event.deployment_status.state == 'success'
+    timeout-minutes: 10
     runs-on: ubuntu-22.04
     container: mcr.microsoft.com/playwright:v1.30.0-focal
 
@@ -24,6 +22,8 @@ jobs:
 
       - name: Run Playwright tests
         run: npx playwright test
+        env:
+          BASE_URL: ${{ github.event.deployment_status.target_url }}
 
       - uses: actions/upload-artifact@v3
         if: always()

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -2,11 +2,11 @@ name: Playwright E2E Smoke Tests
 on: deployment_status
 
 jobs:
-  runTests:
+  e2e-tests:
     if: github.event.deployment_status.state == 'success'
     timeout-minutes: 10
     runs-on: ubuntu-22.04
-    container: mcr.microsoft.com/playwright:v1.30.0-focal
+    container: mcr.microsoft.com/playwright:v1.31.1-focal
 
     steps:
       - uses: actions/checkout@v3

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -25,20 +25,28 @@ export default defineConfig({
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  retries: process.env.CI ? 1 : 0,
   /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 2 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
-    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
-    actionTimeout: 0,
+  
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL: process.env.CI ? process.env.BASE_URL : 'http://localhost:3000',
 
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 5000,
+
+    /* Ignore HTTPS errors */
+    ignoreHTTPSErrors: true,
+
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: process.env.CI ? 'on' : 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:3000',
+    baseURL: process.env.CI ? process.env.BASE_URL : 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
@@ -81,5 +81,6 @@ export default defineConfig({
   webServer: {
     command: 'npm run start',
     port: 3000,
+    reuseExistingServer: !process.env.CI,
   },
 });


### PR DESCRIPTION
Updated GitHub Actions workflow:
- using `deployment_status` for trigger
- env changed from `localhost` to `Vercel Preview` env on CI
- updated `baseURL` to use Vercel Preview / Localhost depending on run environment